### PR TITLE
Fix flaky 401s

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,10 +380,10 @@ spec:
           issuerUrl: http://keycloak.keycloak.svc.cluster.local:8080/realms/kuadrant
     response:
       success:
-        headers:
-          authorization:
+        dynamicMetadata:
+          token:
             wristband:
-              issuer: http://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/kuadrant-multi-cluster-gateways/ap-kuadrant-multi-cluster-gateways-north-south/authorization
+              issuer: http://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/kuadrant-multi-cluster-gateways/ap-kuadrant-multi-cluster-gateways-north-south/token
               customClaims:
                 "scope":
                   selector: request.host
@@ -393,10 +393,10 @@ spec:
               signingKeyRefs:
               - name: wristband-signing-key
                 algorithm: ES256
-          append-prefix:
-            key: authorization
+        headers:
+          authorization:
             plain:
-              selector: "Wristband {auth.response.authorization}"
+              selector: "Wristband {auth.response.token}"
             priority: 1
           host:
             plain:
@@ -488,7 +488,7 @@ spec:
     authentication:
       "east-west":
         jwt:
-          issuerUrl: http://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/kuadrant-multi-cluster-gateways/ap-kuadrant-multi-cluster-gateways-north-south/authorization
+          issuerUrl: http://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/kuadrant-multi-cluster-gateways/ap-kuadrant-multi-cluster-gateways-north-south/token
         credentials:
           authorizationHeader:
             prefix: Wristband
@@ -687,10 +687,10 @@ spec:
           issuerUrl: http://keycloak.keycloak.svc.cluster.local:8080/realms/kuadrant
     response:
       success:
-        headers:
-          authorization:
+        dynamicMetadata:
+          token:
             wristband:
-              issuer: http://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/kuadrant-multi-cluster-gateways/ap-kuadrant-multi-cluster-gateways-north-south/authorization
+              issuer: http://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/kuadrant-multi-cluster-gateways/ap-kuadrant-multi-cluster-gateways-north-south/token
               customClaims:
                 "scope":
                   selector: request.host
@@ -700,10 +700,10 @@ spec:
               signingKeyRefs:
               - name: wristband-signing-key
                 algorithm: ES256
-          append-prefix:
-            key: authorization
+        headers:
+          authorization:
             plain:
-              selector: "Wristband {auth.response.authorization}"
+              selector: "Wristband {auth.response.token}"
             priority: 1
           host:
             plain:


### PR DESCRIPTION
Fixes flaky `401 Unauthorized` responses, randomly triggered due to having in the AuthPolicy multiple response rules meant to inject data in the same response header.

Authorino evaluates the response rules respecting the specified priority, and therefore produces and adds data to the authorization JSON in the right order. However, when the data is injected as response header values, due to [using a simple Golang map to handle those values over](https://github.com/Kuadrant/authorino/blob/9da0bf6d9afce55ec3ff280fe7c28b54e7a5e6ab/pkg/service/auth_pipeline.go#L486), the order can no longer be guaranteed [when building the external authorization response](https://github.com/Kuadrant/authorino/blob/9da0bf6d9afce55ec3ff280fe7c28b54e7a5e6ab/pkg/service/auth.go#L406) later on.