### PR TITLE
Add sub claim to the wristband token

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ spec:
                   selector: request.host
                 "region":
                   value: us
+                "sub":
+                  selector: auth.identity.sub
               tokenDuration: 10
               signingKeyRefs:
               - name: wristband-signing-key
@@ -696,6 +698,8 @@ spec:
                   selector: request.host
                 "region":
                   value: eu
+                "sub":
+                  selector: auth.identity.sub
               tokenDuration: 10
               signingKeyRefs:
               - name: wristband-signing-key


### PR DESCRIPTION
Adds `sub` claim to the wristband token.

Otherwise we cannot do authenticated-RL per user.